### PR TITLE
Fix to crashlytics Report 32

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ proguard/
 
 .gitignore.orig
 app/src/main/assets/crashlytics-build.properties
+app/src/main/res/drawable-hdpi/Thumbs.db

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,7 +13,8 @@
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_short_name"
-        android:theme="@style/ThemeKatg" >
+        android:theme="@style/ThemeKatg"
+        android:largeHeap="true">
         <meta-data
             android:name="com.crashlytics.ApiKey"
             android:value="48dbf78187c50c1b67191d33e57b549d459cca14" />


### PR DESCRIPTION
Added large heap for the app to support larger images and resources
